### PR TITLE
Add lacking import

### DIFF
--- a/build-py3.py
+++ b/build-py3.py
@@ -8,6 +8,7 @@ import psMat
 import json
 import csv
 import os
+import sys
 
 version = '1.0.0'
 today = datetime.date.today()


### PR DESCRIPTION
`make all` currently fails with

```
fontforge -lang=py -script "build-py2.py" "RictyDiminished/RictyDiminished-Regular.ttf" "FiraCode/distr/otf/FiraCode-Regular.otf" "RictyDiminished-with-FiraCode-Regular-unlinked.ttf" Regular false
Copyright (c) 2000-2012 by George Williams.
 Executable based on sources from 14:57 GMT 31-Jul-2012-ML.
 Library based on sources from 14:57 GMT 31-Jul-2012.
Traceback (most recent call last):
  File "build-py2.py", line 26, in <module>
    options = parser.parse_args(sys.argv[1:])
NameError: name 'sys' is not defined
Makefile:28: recipe for target 'RictyDiminished-with-FiraCode-Regular-unlinked.ttf' failed
make: *** [RictyDiminished-with-FiraCode-Regular-unlinked.ttf] Error 1
```

This fixes it.
