### PR TITLE
Unify build.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
-language: python
-python: 3.8
-sudo: required
-install:
-  - sudo add-apt-repository ppa:fontforge/fontforge -y
-  - sudo apt-get update -qq
-  - sudo apt-get install fontforge
-  - pip install -r requirements.txt
-  - pip install https://github.com/behdad/fonttools/zipball/master
+dist: bionic
+addons:
+  apt:
+    sources:
+      # for some reason python3-fontforge is only available in focal
+      - sourceline: 'deb http://us.archive.ubuntu.com/ubuntu/ focal main restricted'
+      - sourceline: 'deb http://us.archive.ubuntu.com/ubuntu/ focal universe'
+    packages:
+      - python3
+      - python3-fontforge
+      - python3-jinja2
+      - python3-fonttools
 script:
   - make
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PYTHON = python3
 REGULAR = RictyDiminished-with-FiraCode-Regular.ttf
 REGULAR_UNLINK = RictyDiminished-with-FiraCode-Regular-unlinked.ttf
 BOLD = RictyDiminished-with-FiraCode-Bold.ttf
@@ -10,38 +11,30 @@ BOLD_DISCORD_UNLINK = RictyDiminishedDiscord-with-FiraCode-Bold-unlinked.ttf
 all: $(REGULAR) $(BOLD) $(REGULAR_DISCORD) $(BOLD_DISCORD)
 
 $(REGULAR): $(REGULAR_UNLINK) ligatures.fea
-	python apply-feature.py "$(word 1, $^)" "$@"
+	$(PYTHON) apply-feature.py "$(word 1, $^)" "$@"
 
 $(BOLD): $(BOLD_UNLINK) ligatures.fea
-	python apply-feature.py "$(word 1, $^)" "$@"
+	$(PYTHON) apply-feature.py "$(word 1, $^)" "$@"
 
 $(REGULAR_DISCORD): $(REGULAR_DISCORD_UNLINK) ligatures.fea
-	python apply-feature.py "$(word 1, $^)" "$@"
+	$(PYTHON) apply-feature.py "$(word 1, $^)" "$@"
 
 $(BOLD_DISCORD): $(BOLD_DISCORD_UNLINK) ligatures.fea
-	python apply-feature.py "$(word 1, $^)" "$@"
+	$(PYTHON) apply-feature.py "$(word 1, $^)" "$@"
 
 ligatures.fea: ligatures.fea.jinja2 data.json build-feature.py
-	python build-feature.py
+	$(PYTHON) build-feature.py
 
-$(REGULAR_UNLINK): build-py2.py RictyDiminished/RictyDiminished-Regular.ttf FiraCode/distr/otf/FiraCode-Regular.otf
-	fontforge -lang=py -script "$<" "$(word 2, $^)" "$(word 3, $^)" "$@" Regular false
+$(REGULAR_UNLINK): RictyDiminished/RictyDiminished-Regular.ttf FiraCode/distr/otf/FiraCode-Regular.otf
+	$(PYTHON) build.py "$(word 1, $^)" "$(word 2, $^)" "$@" Regular false
 
-$(BOLD_UNLINK): build-py2.py RictyDiminished/RictyDiminished-Bold.ttf FiraCode/distr/otf/FiraCode-Bold.otf
-	fontforge -lang=py -script "$<" "$(word 2, $^)" "$(word 3, $^)" "$@" Bold false
+$(BOLD_UNLINK): RictyDiminished/RictyDiminished-Bold.ttf FiraCode/distr/otf/FiraCode-Bold.otf
+	$(PYTHON) build.py "$(word 1, $^)" "$(word 2, $^)" "$@" Bold false
 
-$(REGULAR_DISCORD_UNLINK): build-py2.py RictyDiminished/RictyDiminishedDiscord-Regular.ttf FiraCode/distr/otf/FiraCode-Regular.otf
-	fontforge -lang=py -script "$<" "$(word 2, $^)" "$(word 3, $^)" "$@" Regular true
+$(REGULAR_DISCORD_UNLINK): RictyDiminished/RictyDiminishedDiscord-Regular.ttf FiraCode/distr/otf/FiraCode-Regular.otf
+	$(PYTHON) build.py "$(word 1, $^)" "$(word 2, $^)" "$@" Regular true
 
-$(BOLD_DISCORD_UNLINK): build-py2.py RictyDiminished/RictyDiminishedDiscord-Bold.ttf FiraCode/distr/otf/FiraCode-Bold.otf
-	fontforge -lang=py -script "$<" "$(word 2, $^)" "$(word 3, $^)" "$@" Bold true
+$(BOLD_DISCORD_UNLINK): RictyDiminished/RictyDiminishedDiscord-Bold.ttf FiraCode/distr/otf/FiraCode-Bold.otf
+	$(PYTHON) build.py "$(word 1, $^)" "$(word 2, $^)" "$@" Bold true
 
-build-py2.py: build-py3.py ligatures.csv
-	3to2 "$<" -w -x str
-	mv -f "$<" "$@"
-	mv -f "$<.bak" "$<"
-
-clean:
-	-rm -f build-py2.py
-
-.PHONY: all clean
+.PHONY: all

--- a/build.py
+++ b/build.py
@@ -33,7 +33,7 @@ ricty = fontforge.open(options.ricty)
 firacode = fontforge.open(options.firacode)
 
 # Load ligatures data and create data to generate feature file
-with open('ligatures.csv', 'rb') as file:
+with open('ligatures.csv', 'r') as file:
     ligatures_reader = csv.reader(file, delimiter=' ')
 
     ligatures = []
@@ -57,10 +57,10 @@ nullable_glyphs = list(set(nullable_glyphs))
 
 # Dump data
 with open('data.json', 'w') as file:
-    file.write(unicode(json.dumps({
+    file.write(json.dumps({
         'ligatures': ligatures,
         'nullable_glyphs': nullable_glyphs,
-    })))
+    }))
 
 # Copy needed glyphs from Fira Code font to Ricty
 for (source_type, name) in glyphs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-3to2==1.1.1
-Jinja2==2.8
-https://github.com/behdad/fonttools/zipball/master


### PR DESCRIPTION
There is no need for two different Python versions – fontforge can support Python 3 just fine.

Since Python 2 is dying in [less than a week](https://pythonclock.org/) I decided to tweak the scripts to allow running using a single version.

Successfully built with:

| Python | fontforge | fonttools |
|--------|-----------|-----------|
| 2.7.17 | 20190413  | 3.42.0    |
| 3.5.9  | 20190413  | 3.42.0    |
| 3.7.5  | 20190413  | 3.42.0    |
| 3.7.5  | 20190413  | 4.0.2     |